### PR TITLE
solving issue with FMT

### DIFF
--- a/pandar_monitor/src/pandar_monitor.cpp
+++ b/pandar_monitor/src/pandar_monitor.cpp
@@ -17,6 +17,7 @@
 
 #include "pandar_monitor/pandar_monitor.hpp"
 #include <boost/algorithm/string/join.hpp>
+#define FMT_HEADER_ONLY
 #include <fmt/format.h>
 
 PandarMonitor::PandarMonitor()


### PR DESCRIPTION
Problem: pandar_monitor.cpp:(.text+0x1773): undefined reference to `fmt::v7::detail::vformat[abi:cxx11](fmt::v7::basic_string_view<char>, fmt::v7::format_args

Optional header-only configuration enabled with the FMT_HEADER_ONLY macro https://github.com/fmtlib/fmt#features