### PR TITLE
[improve][pandar_monitor] Enable reconnection without killing the process

### DIFF
--- a/pandar_monitor/src/pandar_monitor.cpp
+++ b/pandar_monitor/src/pandar_monitor.cpp
@@ -55,7 +55,7 @@ void PandarMonitor::checkConnection(diagnostic_updater::DiagnosticStatusWrapper 
     disconnect_ += 1;
     if ( disconnect_ > timeout_ ) {
       ROS_ERROR("Connection Timeout!");
-      exit(1);
+      client_ = std::make_unique<pandar_api::TCPClient>(ip_address_, static_cast<int>(timeout_ * 1000));
     }
     return;
   }
@@ -68,6 +68,11 @@ void PandarMonitor::checkConnection(diagnostic_updater::DiagnosticStatusWrapper 
 
 void PandarMonitor::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
+  if(disconnect_ > 0){
+    stat.summary(DiagStatus::ERROR, "Disconnected");
+    return;
+  }
+
   pandar_api::LidarStatus status;
   auto code = client_->getLidarStatus(status);
   if(code != pandar_api::TCPClient::ReturnCode::SUCCESS){
@@ -125,6 +130,11 @@ void PandarMonitor::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper
 
 void PandarMonitor::checkPTP(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
+  if(disconnect_ > 0){
+    stat.summary(DiagStatus::ERROR, "Disconnected");
+    return;
+  }
+  
   pandar_api::LidarStatus status;
   auto code = client_->getLidarStatus(status);
   if(code != pandar_api::TCPClient::ReturnCode::SUCCESS){
@@ -143,6 +153,11 @@ void PandarMonitor::onTimer(const ros::TimerEvent & event) { updater_.force_upda
 
 void PandarMonitor::checkGPSPPS(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
+  if(disconnect_ > 0){
+    stat.summary(DiagStatus::ERROR, "Disconnected");
+    return;
+  }
+
   /* get LiDAR status*/
   pandar_api::LidarStatus status;
   auto code = client_->getLidarStatus(status);
@@ -165,6 +180,11 @@ void PandarMonitor::checkGPSPPS(diagnostic_updater::DiagnosticStatusWrapper & st
 
 void PandarMonitor::checkGPSGPRMC(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
+  if(disconnect_ > 0){
+    stat.summary(DiagStatus::ERROR, "Disconnected");
+    return;
+  }
+  
   /* get LiDAR status*/
   pandar_api::LidarStatus status;
   auto code = client_->getLidarStatus(status);

--- a/pandar_monitor/src/pandar_monitor.cpp
+++ b/pandar_monitor/src/pandar_monitor.cpp
@@ -69,7 +69,7 @@ void PandarMonitor::checkConnection(diagnostic_updater::DiagnosticStatusWrapper 
 void PandarMonitor::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   if(disconnect_ > 0){
-    stat.summary(DiagStatus::ERROR, "Disconnected");
+    stat.summary(DiagStatus::OK, "Disconnected");
     return;
   }
 
@@ -131,7 +131,7 @@ void PandarMonitor::checkTemperature(diagnostic_updater::DiagnosticStatusWrapper
 void PandarMonitor::checkPTP(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   if(disconnect_ > 0){
-    stat.summary(DiagStatus::ERROR, "Disconnected");
+    stat.summary(DiagStatus::OK, "Disconnected");
     return;
   }
   
@@ -154,7 +154,7 @@ void PandarMonitor::onTimer(const ros::TimerEvent & event) { updater_.force_upda
 void PandarMonitor::checkGPSPPS(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   if(disconnect_ > 0){
-    stat.summary(DiagStatus::ERROR, "Disconnected");
+    stat.summary(DiagStatus::OK, "Disconnected");
     return;
   }
 
@@ -181,7 +181,7 @@ void PandarMonitor::checkGPSPPS(diagnostic_updater::DiagnosticStatusWrapper & st
 void PandarMonitor::checkGPSGPRMC(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   if(disconnect_ > 0){
-    stat.summary(DiagStatus::ERROR, "Disconnected");
+    stat.summary(DiagStatus::OK, "Disconnected");
     return;
   }
   


### PR DESCRIPTION
## [bugfix/timeout_not_work](https://github.com/MapIV/hesai_pandar/tree/bugfix/timeout_not_work)の修正案

### 対処問題
- センサとの接続が切れた際，ダイアグが一定時間`Stale`になるという問題

### 対処方法
- 接続が切れた際には，プロセスごと落とさず，プロセス内で再接続を行うように変更
- 接続が切れている間は，データにアクセスせず，ダイアグは接続が切れている旨を返すように変更

### テスト結果
#### テスト方法
LidarとJetson拡張ボードが繋がるetherコネクタを抜き差しする
####  期待される挙動
- `Runtime Monitor`の`pandar_monitor`:`pandar_connection`のステータスが，
コネクタを抜くと`Errors`に，再び刺すと`Ok`になる
- コネクタを抜いている際は，`pandar_connection`以外の`pandar_monitor`のステータスが
`Disconnected`になる
####  実際の挙動
期待される挙動すべてが再現されることが確認できた
