### PR TITLE
[fix][pandar_pointcloud] fix xt32 launch file default parameters

### DIFF
--- a/pandar_pointcloud/launch/pandarXT32.launch.xml
+++ b/pandar_pointcloud/launch/pandarXT32.launch.xml
@@ -10,7 +10,7 @@
   <arg name="return_mode" default="Dual"/>
   <arg name="model" default="PandarXT-32"/>
   <arg name="frame_id" default="pandar"/>
-  <arg name="calibration" default="$(find-pkg-share pandar_pointcloud)/config/40p.csv"/>
+  <arg name="calibration" default="$(find-pkg-share pandar_pointcloud)/config/xt32.csv"/>
 
   <!-- pandar driver -->
   <node pkg="pandar_driver" exec="pandar_driver_node" name="pandar_driver" output="screen" >

--- a/pandar_pointcloud/launch/pandarXT32.launch.xml
+++ b/pandar_pointcloud/launch/pandarXT32.launch.xml
@@ -8,7 +8,7 @@
   <arg name="scan_phase"  default="0.0"/>
   <arg name="dual_return_distance_threshold" default="0.1"/>
   <arg name="return_mode" default="Dual"/>
-  <arg name="model" default="Pandar-XT32"/>
+  <arg name="model" default="PandarXT-32"/>
   <arg name="frame_id" default="pandar"/>
   <arg name="calibration" default="$(find-pkg-share pandar_pointcloud)/config/40p.csv"/>
 


### PR DESCRIPTION
# Purpose
- Resolve errors during launch file execution
# Details
- https://github.com/MapIV/hesai_pandar/blob/39f50e723316b2f778df87046b3d91df54cab2ed/pandar_pointcloud/src/pandar_cloud.cpp#L70
- Align with comparisons within the code and other naming conventions