### PR TITLE
[fix] pointcloud_raw_ex not publish with XTM

### DIFF
--- a/pandar_pointcloud/src/pandar_cloud.cpp
+++ b/pandar_pointcloud/src/pandar_cloud.cpp
@@ -233,6 +233,7 @@ void PandarCloud::onProcessScan(const pandar_msgs::PandarScan::ConstPtr& scan_ms
         pointcloud->header.stamp = pcl_conversions::toPCL(ros::Time(pointcloud->points[0].time_stamp));
         pointcloud->header.frame_id = scan_msg->header.frame_id;
         pointcloud->height = 1;
+        pointcloud->width = pointcloud->points.size();
 
         pandar_points_ex_pub_.publish(pointcloud);
         if (pandar_points_pub_.getNumSubscribers() > 0) {
@@ -258,6 +259,7 @@ void PandarCloud::onProcessScan2(const pandar_msgs::PandarScan2::ConstPtr& scan_
         pointcloud->header.stamp = pcl_conversions::toPCL(ros::Time(pointcloud->points[0].time_stamp));
         pointcloud->header.frame_id = scan_msg->header.frame_id;
         pointcloud->height = 1;
+        pointcloud->width = pointcloud->points.size();
 
         pandar_points_ex_pub_.publish(pointcloud);
         if (pandar_points_pub_.getNumSubscribers() > 0) {


### PR DESCRIPTION
points_raw_exが空のデータになってpublishされる（XTでは出てたのでXTMだけ？）
publish直前のsize()を見ると確かに点群は存在する

XTMだけ？pointcloud->widthが設定されていないのが原因とのことで、これを修正

### 動作確認
1hの屋外走行データをデコードして出力の周期を確認
1つも欠損なく出力されたのでOK
<img width="760" height="520" alt="image" src="https://github.com/user-attachments/assets/55d288c2-b667-4caf-b2b1-5761fa5e5310" />
