### PR TITLE
fix: set pointcloud width field for pointcloud_raw_ex topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## v2.3.1
+
+### Fixed
+- pointcloud_raw_exトピックのパブリッシュ時にwidthフィールドが設定されていなかった問題を修正
+
+
 ## v2.3.0
 
 ### Changed

--- a/pandar_pointcloud/src/pandar_cloud.cpp
+++ b/pandar_pointcloud/src/pandar_cloud.cpp
@@ -223,6 +223,7 @@ void PandarCloud::onProcessScan(const pandar_msgs::PandarScan::ConstPtr& scan_ms
         pointcloud->header.stamp = pcl_conversions::toPCL(ros::Time(pointcloud->points[0].time_stamp));
         pointcloud->header.frame_id = scan_msg->header.frame_id;
         pointcloud->height = 1;
+        pointcloud->width = pointcloud->points.size();
 
         pandar_points_ex_pub_.publish(pointcloud);
         if (pandar_points_pub_.getNumSubscribers() > 0) {


### PR DESCRIPTION
## Summary

- Fixes missing `width` field assignment when publishing `pointcloud_raw_ex` topic in `PandarCloud::onProcessScan`
- `pointcloud->width` was not being set, which could cause downstream consumers (e.g., PCL-based nodes) to receive a malformed point cloud

## Changes

- `pandar_pointcloud/src/pandar_cloud.cpp`: Add `pointcloud->width = pointcloud->points.size();` before publishing `pandar_points_ex_pub_`

## Background

For an unorganized point cloud (`height = 1`), PCL convention requires `width` to equal the total number of points. Without this, the published cloud is technically invalid and may be rejected or misinterpreted by downstream nodes.

## Test plan

- [ ] Build on ROS 1 (Noetic) and verify `pointcloud_raw_ex` topic publishes a point cloud with correct `width` and `height` fields
- [ ] Confirm `pointcloud_raw` topic is unaffected